### PR TITLE
ANOVA

### DIFF
--- a/frontend.js
+++ b/frontend.js
@@ -39,7 +39,7 @@ function familyChanged() {
         addSelectOption(testSelector, "Proportions: Sign test (binomial test)", false, 8);
     } else if (family == "f") {
         addSelectOption(testSelector, "ANCOVA: Fixed effects, main effects, and interactions", false, 1);
-        addSelectOption(testSelector, "ANOVA: Fixed effects, omnibus, one-way", false, 2);
+        addSelectOption(testSelector, "ANOVA: Fixed effects, omnibus, one-way", true, 'oneWayANOVA');
         addSelectOption(testSelector, "ANOVA: Fixed effects, special, main effects, and interactions", false, 3);
         addSelectOption(testSelector, "ANOVA: Repeated measures, between factors", false, 4);
         addSelectOption(testSelector, "ANOVA: Repeated measures, within factors", false, 5);
@@ -141,6 +141,8 @@ function updateNumberOutputAreas() {
         } else if (test == "increaseMultipleRegression") {
             addTableOption(inputTable, "Number of tested predictors", "<input onchange='updateOutput()' id='q' value='2' min='0' max='1000' step='1'>");
             addTableOption(inputTable, "Total number of predictors", "<input onchange='updateOutput()' id='p' value='5' min='0' max='1000' step='1'>");
+        } else if (test == "oneWayANOVA") {
+            addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='5' min='0' max='1000' step='1'>");
         }
     } else if (family == "t") {
         addTableOption(inputTable, "Tail(s)", "<select onchange='updateOutput()' id='tail'><option value=1>One tail</option><option value=2>Two tails</option></select>");

--- a/frontend.js
+++ b/frontend.js
@@ -42,8 +42,8 @@ function familyChanged() {
         addSelectOption(testSelector, "ANOVA: Fixed effects, omnibus, one-way", true, 'oneWayANOVA');
         addSelectOption(testSelector, "ANOVA: Fixed effects, special, main effects, and interactions", true , 'twoWayANOVA');
         addSelectOption(testSelector, "ANOVA: Repeated measures, between factors",true, 'betweenRepeatedANOVA');
-        addSelectOption(testSelector, "ANOVA: Repeated measures, within factors", false, 5);
-        addSelectOption(testSelector, "ANOVA: Repeated measures, within-between interaction", false, 6);
+        addSelectOption(testSelector, "ANOVA: Repeated measures, within factors", true, 'withinRepeatedANOVA');
+        addSelectOption(testSelector, "ANOVA: Repeated measures, within-between interaction", true, 'withinBetweenRepeatedANOVA');
         addSelectOption(testSelector, "Hotellings T²: One group mean vector", false, 7);
         addSelectOption(testSelector, "Hotellings T²: Two group mean vector", false, 8);
         addSelectOption(testSelector, "MANOVA: Global effects", false, 9);
@@ -152,8 +152,14 @@ function updateNumberOutputAreas() {
             addTableOption(inputTable, "Number of covariates", "<input onchange='updateOutput()' id='p' value='2' min='2' max='1000' step='1'>");
         } else if (test == "betweenRepeatedANOVA") {
             addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='2' min='0' max='1000' step='1'>");
-            addTableOption(inputTable, "Number of measurement", "<input onchange='updateOutput()' id='m' value='1' min='0' max='1000' step='1'>");
+            addTableOption(inputTable, "Number of measurement", "<input onchange='updateOutput()' id='m' value='2' min='2' max='1000' step='1'>");
             addTableOption(inputTable, "Corr among rep measures", "<input onchange='updateOutput()' id='rho' value='0.5' min='0' max='1' step='0.1'>");
+        } else if (test == "withinRepeatedANOVA" || test == "withinBetweenRepeatedANOVA") {
+            addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='2' min='0' max='1000' step='1'>");
+            addTableOption(inputTable, "Number of measurement", "<input onchange='updateOutput()' id='m' value='2' min='2' max='1000' step='1'>");
+            addTableOption(inputTable, "Corr among rep measures", "<input onchange='updateOutput()' id='rho' value='0.5' min='0' max='1' step='0.1'>");
+            // FIXME: the lower bound of epsilon corresponds to 1 / (number of measurements - 1)
+            addTableOption(inputTable, "Nonsphericity correction ε", "<input onchange='updateOutput()' id='epsilon' value='1' min='0' max='1' step='0.1'>");
         }
     } else if (family == "t") {
         addTableOption(inputTable, "Tail(s)", "<select onchange='updateOutput()' id='tail'><option value=1>One tail</option><option value=2>Two tails</option></select>");

--- a/frontend.js
+++ b/frontend.js
@@ -38,7 +38,7 @@ function familyChanged() {
         addSelectOption(testSelector, "Proportions: Inequality (offset), two independent groups (unconditional)", false, 7);
         addSelectOption(testSelector, "Proportions: Sign test (binomial test)", false, 8);
     } else if (family == "f") {
-        addSelectOption(testSelector, "ANCOVA: Fixed effects, main effects, and interactions", false, 1);
+        addSelectOption(testSelector, "ANCOVA: Fixed effects, main effects, and interactions", true, 'ANCOVA');
         addSelectOption(testSelector, "ANOVA: Fixed effects, omnibus, one-way", true, 'oneWayANOVA');
         addSelectOption(testSelector, "ANOVA: Fixed effects, special, main effects, and interactions", true , 'twoWayANOVA');
         addSelectOption(testSelector, "ANOVA: Repeated measures, between factors", false, 4);
@@ -146,6 +146,10 @@ function updateNumberOutputAreas() {
         } else if (test == "twoWayANOVA") {
             addTableOption(inputTable, "Numerator df", "<input onchange='updateOutput()' id='q' value='10' min='0' max='1000' step='1'>");
             addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='5' min='0' max='1000' step='1'>");
+        } else if (test == "ANCOVA") {
+            addTableOption(inputTable, "Numerator df", "<input onchange='updateOutput()' id='q' value='10' min='0' max='1000' step='1'>");
+            addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='5' min='0' max='1000' step='1'>");
+            addTableOption(inputTable, "Number of covariates", "<input onchange='updateOutput()' id='p' value='1' min='0' max='1000' step='1'>");
         }
     } else if (family == "t") {
         addTableOption(inputTable, "Tail(s)", "<select onchange='updateOutput()' id='tail'><option value=1>One tail</option><option value=2>Two tails</option></select>");

--- a/frontend.js
+++ b/frontend.js
@@ -142,17 +142,17 @@ function updateNumberOutputAreas() {
             addTableOption(inputTable, "Number of tested predictors", "<input onchange='updateOutput()' id='q' value='2' min='0' max='1000' step='1'>");
             addTableOption(inputTable, "Total number of predictors", "<input onchange='updateOutput()' id='p' value='5' min='0' max='1000' step='1'>");
         } else if (test == "oneWayANOVA") {
-            addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='5' min='0' max='1000' step='1'>");
+            addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='5' min='1' max='1000' step='1'>");
         } else if (test == "twoWayANOVA") {
-            addTableOption(inputTable, "Numerator df", "<input onchange='updateOutput()' id='q' value='10' min='0' max='1000' step='1'>");
-            addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='5' min='0' max='1000' step='1'>");
+            addTableOption(inputTable, "Numerator df", "<input onchange='updateOutput()' id='q' value='10' min='1' max='1000' step='1'>");
+            addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='5' min='1' max='1000' step='1'>");
         } else if (test == "ANCOVA") {
-            addTableOption(inputTable, "Numerator df", "<input onchange='updateOutput()' id='q' value='10' min='0' max='1000' step='1'>");
-            addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='5' min='0' max='1000' step='1'>");
-            addTableOption(inputTable, "Number of covariates", "<input onchange='updateOutput()' id='p' value='1' min='0' max='1000' step='1'>");
+            addTableOption(inputTable, "Numerator df", "<input onchange='updateOutput()' id='q' value='10' min='1' max='1000' step='1'>");
+            addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='5' min='1' max='1000' step='1'>");
+            addTableOption(inputTable, "Number of covariates", "<input onchange='updateOutput()' id='p' value='2' min='2' max='1000' step='1'>");
         } else if (test == "betweenRepeatedANOVA") {
             addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='2' min='0' max='1000' step='1'>");
-            addTableOption(inputTable, "Number of measurement", "<input onchange='updateOutput()' id='4' value='1' min='0' max='1000' step='1'>");
+            addTableOption(inputTable, "Number of measurement", "<input onchange='updateOutput()' id='m' value='1' min='0' max='1000' step='1'>");
             addTableOption(inputTable, "Corr among rep measures", "<input onchange='updateOutput()' id='rho' value='0.5' min='0' max='1' step='0.1'>");
         }
     } else if (family == "t") {

--- a/frontend.js
+++ b/frontend.js
@@ -40,7 +40,7 @@ function familyChanged() {
     } else if (family == "f") {
         addSelectOption(testSelector, "ANCOVA: Fixed effects, main effects, and interactions", false, 1);
         addSelectOption(testSelector, "ANOVA: Fixed effects, omnibus, one-way", true, 'oneWayANOVA');
-        addSelectOption(testSelector, "ANOVA: Fixed effects, special, main effects, and interactions", false, 3);
+        addSelectOption(testSelector, "ANOVA: Fixed effects, special, main effects, and interactions", true , 'twoWayANOVA');
         addSelectOption(testSelector, "ANOVA: Repeated measures, between factors", false, 4);
         addSelectOption(testSelector, "ANOVA: Repeated measures, within factors", false, 5);
         addSelectOption(testSelector, "ANOVA: Repeated measures, within-between interaction", false, 6);
@@ -142,6 +142,9 @@ function updateNumberOutputAreas() {
             addTableOption(inputTable, "Number of tested predictors", "<input onchange='updateOutput()' id='q' value='2' min='0' max='1000' step='1'>");
             addTableOption(inputTable, "Total number of predictors", "<input onchange='updateOutput()' id='p' value='5' min='0' max='1000' step='1'>");
         } else if (test == "oneWayANOVA") {
+            addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='5' min='0' max='1000' step='1'>");
+        } else if (test == "twoWayANOVA") {
+            addTableOption(inputTable, "Numerator df", "<input onchange='updateOutput()' id='q' value='10' min='0' max='1000' step='1'>");
             addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='5' min='0' max='1000' step='1'>");
         }
     } else if (family == "t") {

--- a/frontend.js
+++ b/frontend.js
@@ -41,7 +41,7 @@ function familyChanged() {
         addSelectOption(testSelector, "ANCOVA: Fixed effects, main effects, and interactions", true, 'ANCOVA');
         addSelectOption(testSelector, "ANOVA: Fixed effects, omnibus, one-way", true, 'oneWayANOVA');
         addSelectOption(testSelector, "ANOVA: Fixed effects, special, main effects, and interactions", true , 'twoWayANOVA');
-        addSelectOption(testSelector, "ANOVA: Repeated measures, between factors", false, 4);
+        addSelectOption(testSelector, "ANOVA: Repeated measures, between factors",true, 'betweenRepeatedANOVA');
         addSelectOption(testSelector, "ANOVA: Repeated measures, within factors", false, 5);
         addSelectOption(testSelector, "ANOVA: Repeated measures, within-between interaction", false, 6);
         addSelectOption(testSelector, "Hotellings T²: One group mean vector", false, 7);
@@ -150,6 +150,10 @@ function updateNumberOutputAreas() {
             addTableOption(inputTable, "Numerator df", "<input onchange='updateOutput()' id='q' value='10' min='0' max='1000' step='1'>");
             addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='5' min='0' max='1000' step='1'>");
             addTableOption(inputTable, "Number of covariates", "<input onchange='updateOutput()' id='p' value='1' min='0' max='1000' step='1'>");
+        } else if (test == "betweenRepeatedANOVA") {
+            addTableOption(inputTable, "Number of groups", "<input onchange='updateOutput()' id='k' value='2' min='0' max='1000' step='1'>");
+            addTableOption(inputTable, "Number of measurement", "<input onchange='updateOutput()' id='4' value='1' min='0' max='1000' step='1'>");
+            addTableOption(inputTable, "Corr among rep measures", "<input onchange='updateOutput()' id='rho' value='0.5' min='0' max='1' step='0.1'>");
         }
     } else if (family == "t") {
         addTableOption(inputTable, "Tail(s)", "<select onchange='updateOutput()' id='tail'><option value=1>One tail</option><option value=2>Two tails</option></select>");

--- a/power/src/power.rs
+++ b/power/src/power.rs
@@ -257,7 +257,7 @@ impl TestKind {
                 Box::new(NoncentralF::new(
                     (*m as f64 - 1.0) * *epsilon,
                     (n - *k as f64) * (*m as f64 - 1.0) * *epsilon,
-                    es.powi(2) * u * n * *epsilon, // NOTE: G*Power paper is missing the epsilon.
+                    es.powi(2) * u * n * *epsilon, // G*Power paper is missing the epsilon.
                 ))
             }
             TestKind::WithinBetweenRepeatedANOVA { k, m, rho, epsilon } => {

--- a/power/src/power.rs
+++ b/power/src/power.rs
@@ -32,11 +32,17 @@ pub enum TestKind {
         /// Number of tested predictors (#B).
         q: i64,
     },
-    IndependentSamplesTTest,
     /// ANOVA: Fixed effects, omnibus, one-way.
     OneWayANOVA {
         /// Number of groups.
         k: i64,
+    },
+    /// ANOVA: Fixed effects, special, main effects and interactions.
+    TwoWayANOVA {
+        /// Total number of cells in the design.
+        k: i64,
+        /// Degrees of freedom of the tested effect.
+        q: i64,
     },
 }
 
@@ -87,12 +93,16 @@ impl TestKind {
             "increaseMultipleRegression" => {
                 let rho = parse_i64(data, "rho").unwrap();
                 let q = parse_i64(data, "q").unwrap();
-                Ok(TestKind::IncreaseMultipleRegression{ p, q })
-            },
-            "independentSamplesTTest" => Ok(TestKind::IndependentSamplesTTest),
+                Ok(TestKind::IncreaseMultipleRegression { rho, q })
+            }
             "oneWayANOVA" => {
                 let k = parse_i64(data, "k").unwrap();
                 Ok(TestKind::OneWayANOVA { k })
+            }
+            "twoWayANOVA" => {
+                let k = parse_i64(data, "k").unwrap();
+                let q = parse_i64(data, "q").unwrap();
+                Ok(TestKind::TwoWayANOVA { k, q })
             }
             _ => Err(format!("Unknown test: {}", text)),
         }
@@ -105,11 +115,29 @@ impl TestKind {
                 let v = n - 2.0; // n1 + n2 - 2
                 Box::new(NoncentralT::new(v, (n / 2.0).sqrt() * es))
             }
+            TestKind::DeviationFromZeroMultipleRegression { n_predictors } => {
+                Box::new(NoncentralF::new(
+                    *n_predictors as f64,
+                    n - (*n_predictors as f64) - 1.0,
+                    es.powi(2) * n,
+                ))
+            }
+            TestKind::GoodnessOfFitChisqTest { df } => {
+                Box::new(NoncentralChisq::new(*df as f64, es.powi(2) * n))
+            }
+            TestKind::IncreaseMultipleRegression { rho, q } => Box::new(NoncentralF::new(
+                *q as f64,
+                n - (*rho as f64) - 1.0,
+                es.powi(2) * n,
+            )),
             TestKind::OneWayANOVA { k } => Box::new(NoncentralF::new(
                 *k as f64 - 1.0,
                 n - *k as f64,
                 es.powi(2) * n,
             )),
+            TestKind::TwoWayANOVA { k, q } => {
+                Box::new(NoncentralF::new(*q as f64, n - *k as f64, es.powi(2) * n))
+            }
         }
     }
 

--- a/power/src/tests.rs
+++ b/power/src/tests.rs
@@ -187,3 +187,32 @@ fn ancova_test() {
     let extra = json!({"k": k, "q": q, "p": p, "analysis": "n"});
     test_interface(&join(&extra), 204.0);
 }
+
+#[test]
+fn between_repeated_anova_test() {
+    let k = "2";
+    let m = "4";
+    let rho = "0.5";
+    let join = with_rest("betweenRepeatedANOVA");
+    let extra = json!({"k": k, "m": m, "rho": rho, "analysis": "alpha"});
+    test_interface(&join(&extra), 0.008);
+    let extra = json!({"k": k, "m": m, "rho": rho, "analysis": "power"});
+    test_interface(&join(&extra), 0.992);
+    let extra = json!({"k": k, "m": m, "rho": rho, "analysis": "es"});
+    test_interface(&join(&extra), 0.411);
+    let extra = json!({"k": k, "m": m, "rho": rho, "analysis": "n"});
+    test_interface(&join(&extra), 36.0);
+
+    let k = "5";
+    let m = "10";
+    let rho = "0.75";
+    let join = with_rest("betweenRepeatedANOVA");
+    let extra = json!({"k": k, "m": m, "rho": rho, "analysis": "alpha"});
+    test_interface(&join(&extra), 0.125);
+    let extra = json!({"k": k, "m": m, "rho": rho, "analysis": "power"});
+    test_interface(&join(&extra), 0.880);
+    let extra = json!({"k": k, "m": m, "rho": rho, "analysis": "es"});
+    test_interface(&join(&extra), 0.566);
+    let extra = json!({"k": k, "m": m, "rho": rho, "analysis": "n"});
+    test_interface(&join(&extra), 65.0);
+}

--- a/power/src/tests.rs
+++ b/power/src/tests.rs
@@ -216,3 +216,102 @@ fn between_repeated_anova_test() {
     let extra = json!({"k": k, "m": m, "rho": rho, "analysis": "n"});
     test_interface(&join(&extra), 65.0);
 }
+
+#[test]
+fn within_repeated_anova_test() {
+    let k = "4";
+    let m = "2";
+    let rho = "0.5";
+    let epsilon = "1.0";
+    let n = 12.0;
+    let join =
+        json!({"n": n, "alpha": ALPHA, "power": POWER, "es": ES, "test": "withinRepeatedANOVA"});
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "alpha"});
+    test_interface(&join_json(&join, &extra), 0.123);
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "power"});
+    test_interface(&join_json(&join, &extra), 0.857);
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "es"});
+    test_interface(&join_json(&join, &extra), 0.597);
+    let join = with_rest("withinRepeatedANOVA");
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "n"});
+    test_interface(&join(&extra), 16.0);
+
+    let k = "4";
+    let m = "3";
+    let rho = "0.75";
+    let epsilon = "0.7";
+    let n = 10.0;
+    let join =
+        json!({"n": n, "alpha": ALPHA, "power": POWER, "es": ES, "test": "withinRepeatedANOVA"});
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "alpha"});
+    test_interface(&join_json(&join, &extra), 0.040);
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "power"});
+    test_interface(&join_json(&join, &extra), 0.963);
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "es"});
+    test_interface(&join_json(&join, &extra), 0.481);
+    let join = with_rest("withinRepeatedANOVA");
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "n"});
+    test_interface(&join(&extra), 10.0);
+}
+
+#[test]
+#[should_panic(expected = "lower bound of ε corresponds to 1 / (number of measurements - 1)")]
+fn within_repeated_anova_epsilon_error() {
+    let k = "4";
+    let m = "2";
+    let rho = "0.5";
+    let epsilon = "0.2"; // lower bound is 1/3.
+    let n = 12.0;
+    let join =
+        json!({"n": n, "alpha": ALPHA, "power": POWER, "es": ES, "test": "withinRepeatedANOVA"});
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "alpha"});
+    test_interface(&join_json(&join, &extra), 0.123);
+}
+
+#[test]
+fn within_between_repeated_anova_test() {
+    let k = "4";
+    let m = "2";
+    let rho = "0.5";
+    let epsilon = "1.0";
+    let n = 15.0;
+    let join = json!({"n": n, "alpha": ALPHA, "power": POWER, "es": ES, "test": "withinBetweenRepeatedANOVA"});
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "alpha"});
+    test_interface(&join_json(&join, &extra), 0.187);
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "power"});
+    test_interface(&join_json(&join, &extra), 0.782);
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "es"});
+    test_interface(&join_json(&join, &extra), 0.644);
+    let join = with_rest("withinBetweenRepeatedANOVA");
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "n"});
+    test_interface(&join(&extra), 24.0);
+
+    let k = "4";
+    let m = "3";
+    let rho = "0.75";
+    let epsilon = "0.7";
+    let n = 12.0;
+    let join = json!({"n": n, "alpha": ALPHA, "power": POWER, "es": ES, "test": "withinBetweenRepeatedANOVA"});
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "alpha"});
+    test_interface(&join_json(&join, &extra), 0.078);
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "power"});
+    test_interface(&join_json(&join, &extra), 0.913);
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "es"});
+    test_interface(&join_json(&join, &extra), 0.539);
+    let join = with_rest("withinBetweenRepeatedANOVA");
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "n"});
+    test_interface(&join(&extra), 16.0);
+}
+
+#[test]
+#[should_panic(expected = "lower bound of ε corresponds to 1 / (number of measurements - 1)")]
+fn within_between_repeated_anova_epsilon_error() {
+    let k = "4";
+    let m = "2";
+    let rho = "0.5";
+    let epsilon = "0.2"; // lower bound is 1/3.
+    let n = 12.0;
+    let join = json!({"n": n, "alpha": ALPHA, "power": POWER, "es": ES, "test": "withinBetweenRepeatedANOVA"});
+    let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "alpha"});
+    test_interface(&join_json(&join, &extra), 0.123);
+}

--- a/power/src/tests.rs
+++ b/power/src/tests.rs
@@ -158,3 +158,32 @@ fn two_way_anova_test() {
     let extra = json!({"k": k, "q": q, "analysis": "n"});
     test_interface(&join(&extra), 107.0);
 }
+
+#[test]
+fn ancova_test() {
+    let k = "5";
+    let q = "10";
+    let p = "2";
+    let join = with_rest("ANCOVA");
+    let extra = json!({"k": k, "q": q, "p": p, "analysis": "alpha"});
+    test_interface(&join(&extra), 0.469); // G*Power gives 0.467
+    let extra = json!({"k": k, "q": q, "p": p, "analysis": "power"});
+    test_interface(&join(&extra), 0.553); // G*Power gives 0.555
+    let extra = json!({"k": k, "q": q, "p": p, "analysis": "es"});
+    test_interface(&join(&extra), 0.775); // G*Power gives 0.773
+    let extra = json!({"k": k, "q": q, "p": p, "analysis": "n"});
+    test_interface(&join(&extra), 107.0);
+
+    let k = "10";
+    let q = "50";
+    let p = "10";
+    let join = with_rest("ANCOVA");
+    let extra = json!({"k": k, "q": q, "p": p, "analysis": "alpha"});
+    test_interface(&join(&extra), 0.826); // G*Power gives 0.825
+    let extra = json!({"k": k, "q": q, "p": p, "analysis": "power"});
+    test_interface(&join(&extra), 0.156); // G*Power gives 0.158
+    let extra = json!({"k": k, "q": q, "p": p, "analysis": "es"});
+    test_interface(&join(&extra), 1.357); // G*Power gives 1.344
+    let extra = json!({"k": k, "q": q, "p": p, "analysis": "n"});
+    test_interface(&join(&extra), 204.0);
+}

--- a/power/src/tests.rs
+++ b/power/src/tests.rs
@@ -201,7 +201,7 @@ fn between_repeated_anova_test() {
     let extra = json!({"k": k, "m": m, "rho": rho, "analysis": "es"});
     test_interface(&join(&extra), 0.411);
     let extra = json!({"k": k, "m": m, "rho": rho, "analysis": "n"});
-    test_interface(&join(&extra), 36.0);
+    test_interface(&join(&extra), 35.0); // G*Power gives 36
 
     let k = "5";
     let m = "10";
@@ -214,7 +214,7 @@ fn between_repeated_anova_test() {
     let extra = json!({"k": k, "m": m, "rho": rho, "analysis": "es"});
     test_interface(&join(&extra), 0.566);
     let extra = json!({"k": k, "m": m, "rho": rho, "analysis": "n"});
-    test_interface(&join(&extra), 65.0);
+    test_interface(&join(&extra), 63.0); // G*Power gives 65
 }
 
 #[test]
@@ -284,7 +284,7 @@ fn within_between_repeated_anova_test() {
     test_interface(&join_json(&join, &extra), 0.644);
     let join = with_rest("withinBetweenRepeatedANOVA");
     let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "n"});
-    test_interface(&join(&extra), 24.0);
+    test_interface(&join(&extra), 22.0); // G*Power gives 24
 
     let k = "4";
     let m = "3";
@@ -300,7 +300,7 @@ fn within_between_repeated_anova_test() {
     test_interface(&join_json(&join, &extra), 0.539);
     let join = with_rest("withinBetweenRepeatedANOVA");
     let extra = json!({"k": k, "m": m, "rho": rho, "epsilon": epsilon, "analysis": "n"});
-    test_interface(&join(&extra), 16.0);
+    test_interface(&join(&extra), 14.0); // G*Power gives 16
 }
 
 #[test]

--- a/power/src/tests.rs
+++ b/power/src/tests.rs
@@ -129,3 +129,17 @@ fn increase_multiple_regression() {
     let extra = json!({"rho": rho, "q": q, "es": f_squared, "analysis": "n"});
     test_interface(&join(&extra), 35.0);
 }
+
+#[test]
+fn one_way_anova_test() {
+    let k = "5";
+    let join = with_rest("oneWayANOVA");
+    let extra = json!({"k": k, "analysis": "alpha"});
+    test_interface(&join(&extra), 0.247);
+    let extra = json!({"k": k, "analysis": "power"});
+    test_interface(&join(&extra), 0.773);
+    let extra = json!({"k": k, "analysis": "es"});
+    test_interface(&join(&extra), 0.643);
+    let extra = json!({"k": k, "analysis": "n"});
+    test_interface(&join(&extra), 80.0);
+}

--- a/power/src/tests.rs
+++ b/power/src/tests.rs
@@ -143,3 +143,18 @@ fn one_way_anova_test() {
     let extra = json!({"k": k, "analysis": "n"});
     test_interface(&join(&extra), 80.0);
 }
+
+#[test]
+fn two_way_anova_test() {
+    let k = "5";
+    let q = "10";
+    let join = with_rest("twoWayANOVA");
+    let extra = json!({"k": k, "q": q, "analysis": "alpha"});
+    test_interface(&join(&extra), 0.465);
+    let extra = json!({"k": k, "q": q, "analysis": "power"});
+    test_interface(&join(&extra), 0.560);
+    let extra = json!({"k": k, "q": q, "analysis": "es"});
+    test_interface(&join(&extra), 0.770);
+    let extra = json!({"k": k, "q": q, "analysis": "n"});
+    test_interface(&join(&extra), 107.0);
+}


### PR DESCRIPTION
- [x] `OneWayANOVA`
- [x] `TwoWayANOVA`
- [x] `ANCOVA`
- [x] `RepeatedBetweenANOVA`
- [x] `WithinRepeatedANOVA`
- [x] `WithinBetweenANOVA`

Tests are broken because for sample size. We need the fix in #12.