### PR TITLE
fix(frontend): easy to read and consistent with G*Power

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,122 +1,129 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <title>PowerAnalyses.org</title>
-        <link rel="stylesheet" href="/style.css">
-        <link rel="icon" href="/favicon.png">
-        <script src="pa.js"></script>
-        <script defer src="frontend.js"></script>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width">
-    </head>
-    <body>
-        <div class="content">
-        <div class="title center">
-            <img class="favicon" src="/favicon.png"/>
-            PowerAnalyses.org Beta
-        </div>
-        <img class="plot center" src=""></img>
 
-        <div class="dropdowns border">
-            <label for="family">
-                Test family:<br>
-                <select id="family" onchange="familyChanged()" name="type">
-                    <option disabled value="exact">Exact</option>
-                    <option value="f">F tests</option>
-                    <option value="t">t tests</option>
-                    <option value="chi">χ² tests</option>
-                    <option disabled value="z">z tests</option>
-                </select><br>
-            </label>
-            <label for="test">
-                Statistical test:<br>
-                <select id="test" onchange="updateNumberOutputAreas()" name="type">
-                    <option value="1">ANCOVA - Fixed effects, main effects, and interactions</option>
-                </select><br>
-            </label>
-            <label for="analysis">
-                Type of power analysis:<br>
-                <select id="analysis" onchange="updateNumberOutputAreas()" name="type">
-                    <option value="n">Compute required sample size (a priori)</option>
-                    <option value="alpha">Compute required α (criterion)</option>
-                    <option value="power">Compute achieved power (post hoc)</option>
-                    <option value="es">Compute required effect size (sensitivity)</option>
-                </select>
-            </label>
-            <br>
-            <br>
+<head>
+  <title>PowerAnalyses.org</title>
+  <link rel="stylesheet" href="/style.css">
+  <link rel="icon" href="/favicon.png">
+  <script src="pa.js"></script>
+  <script defer src="frontend.js"></script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+</head>
+
+<body>
+  <div class="content">
+    <div class="title center">
+      <img class="favicon" src="/favicon.png" />
+      PowerAnalyses.org Beta
+    </div>
+    <img class="plot center" src=""></img>
+
+    <div class="dropdowns border">
+      <label for="family">
+        Test family:<br>
+        <select class="drop-down" id="family" onchange="familyChanged()" name="type">
+          <option disabled value="exact">Exact</option>
+          <option value="f">F tests</option>
+          <option value="t">t tests</option>
+          <option value="chi">χ² tests</option>
+          <option disabled value="z">z tests</option>
+        </select><br>
+      </label>
+      <label for="test">
+        Statistical test:<br>
+        <select class="drop-down" id="test" onchange="updateNumberOutputAreas()" name="type">
+          <option value="1">ANCOVA - Fixed effects, main effects, and interactions</option>
+        </select><br>
+      </label>
+      <label for="analysis">
+        Type of power analysis:<br>
+        <select class="drop-down" id="analysis" onchange="updateNumberOutputAreas()" name="type">
+          <option value="n">Compute required sample size (a priori)</option>
+          <option value="alpha">Compute required α (criterion)</option>
+          <option value="power">Compute achieved power (post hoc)</option>
+          <option value="es">Compute required effect size (sensitivity)</option>
+        </select>
+      </label>
+      <br>
+      <br>
+    </div>
+    <div class="numbers">
+      <div>
+        <table id="input" class="border">
+          <tr>
+            <td>Tail:</td>
+            <td>
+              <select id="tail">
+                <option value="1">One tail</option>
+                <option value="2">Two tails</option>
+              </select>
+            </td>
+          </tr>
+        </table>
+        <div class="output border">
+          <table id="output" class="center">
+            <tbody class="center">
+              <tr>
+                <td>Sample size:</td>
+                <td class="result">
+                  <input id="n" type="number" value="100" min="2" max="99999" step="5" onchange="updateOutput()"
+                    disabled>
+                </td>
+              </tr>
+              <tr>
+                <td>α err prob:</td>
+                <td class="result">
+                  <input id="alpha" type="number" value="0.05" min="0.01" max="0.99" step="0.01"
+                    onchange="updateOutput()">
+                </td>
+              </tr>
+              <tr>
+                <td>Power (1-β err prob):</td>
+                <td class="result">
+                  <input id="power" type="number" value="0.95" min="0" max="0.99" step="0.01" onchange="updateOutput()">
+                </td>
+              </tr>
+              <tr>
+                <td>Effect size:</td>
+                <td class="result">
+                  <input id="es" type="number" value="0.5" min="0" max="100" step="0.05" onchange="updateOutput()">
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <div id="error" class="center error">
+          </div>
+          <div class="center">
+            <button onclick="resetOutput()" class="resetBtn">Reset</button>
+            <button onclick="updateOutput()" class="calculateBtn">Calculate</button>
+          </div>
         </div>
-        <div class="numbers">
-            <div>
-                <table id="input" class="border">
-                <tr>
-                    <td>Tail:</td>
-                    <td>
-                        <select id="tail">
-                            <option value="1">One tail</option>
-                            <option value="2">Two tails</option>
-                        </select>
-                    </td>
-                </tr>
-                </table>
-                <div class="output border">
-                    <table id="output" class="center">
-                    <tbody class="center">
-                    <tr>
-                        <td>Sample size:</td>
-                        <td class="result">
-                            <input id="n" type="number" value="100" min="2" max="99999" step="5" onchange="updateOutput()" disabled>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>α err prob:</td>
-                        <td class="result">
-                            <input id="alpha" type="number" value="0.05" min="0.01" max="0.99" step="0.01" onchange="updateOutput()">
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Power (1-β err prob):</td>
-                        <td class="result">
-                            <input id="power" type="number" value="0.95" min="0" max="0.99" step="0.01" onchange="updateOutput()">
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Effect size:</td>
-                        <td class="result">
-                            <input id="es" type="number" value="0.5" min="0" max="100" step="0.05" onchange="updateOutput()">
-                        </td>
-                    </tr>
-                    </tbody>
-                    </table>
-                    <div id="error" class="center error">
-                    </div>
-                    <div class="center">
-                        <button onclick="resetOutput()" class="resetBtn">Reset</button>
-                        <button onclick="updateOutput()" class="calculateBtn">Calculate</button>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <br>
-        <br>
-        <br>
-        <div style="font-size: 1rem">
-            <center><b>Why this web site?</b></center><br>
-            Statistical power analyses play a key role in science.
-            However, the code for these tools isn't always public.
-            This project shares the code along with the tool, so that people can verify the code and improve it.
-        </div>
-        <br>
-        <br>
-        <br>
-        <div class="center footer">
-            PowerAnalyses.org version <VERSION>.
-            If you find a bug, please open an issue on <a href="https://github.com/rikhuijzer/poweranalyses.org">GitHub</a>.
-            This site was made possible thanks to the
-            <a href="https://www.psychologie.hhu.de/arbeitsgruppen/allgemeine-psychologie-und-arbeitspsychologie/gpower.html">G*Power</a>
-            and
-            <a href="https://github.com/heliosdrm/pwr">pwr</a> projects.
-        </div>
-        </div>
-    </body>
+      </div>
+    </div>
+    <br>
+    <br>
+    <br>
+    <div style="font-size: 1rem">
+      <center><b>Why this web site?</b></center><br>
+      Statistical power analyses play a key role in science.
+      However, the code for these tools isn't always public.
+      This project shares the code along with the tool, so that people can verify the code and improve it.
+    </div>
+    <br>
+    <br>
+    <br>
+    <div class="center footer">
+      PowerAnalyses.org version <VERSION>.
+        If you find a bug, please open an issue on <a
+          href="https://github.com/poweranalyses-org/poweranalyses">GitHub</a>.
+        This site was made possible thanks to the
+        <a
+          href="https://www.psychologie.hhu.de/arbeitsgruppen/allgemeine-psychologie-und-arbeitspsychologie/gpower.html">G*Power</a>
+        and
+        <a href="https://github.com/heliosdrm/pwr">pwr</a> projects.
+    </div>
+  </div>
+</body>
+
 </html>

--- a/style.css
+++ b/style.css
@@ -1,157 +1,169 @@
 :root {
-    --black: #000000;
-    --small: 15px;
-    --medium: 19px;
-    --favicon-blue: #7fb3fa;
-    --favicon-green: #64d465;
-    --favicon-yellow: #f4dd45;
-    --favicon-red: #f87c68;
+  --black: #000000;
+  --small: 15px;
+  --medium: 19px;
+  --large: 24px;
+  --favicon-blue: #7fb3fa;
+  --favicon-green: #64d465;
+  --favicon-yellow: #f4dd45;
+  --favicon-red: #f87c68;
 }
 
 body {
-    font-family: sans-serif;
-    font-size: var(--small);
+  font-family: sans-serif;
+  font-size: var(--medium);
 }
 
 .favicon {
-    vertical-align: bottom;
-    height: 1.7rem;
+  vertical-align: bottom;
+  height: 1.7rem;
 }
 
 @media (min-width: 800px) {
-    body {
-        font-size: var(--medium);
-    }
-    .content {
-        max-width: 640px;
-    }
+  body {
+    font-size: var(--large);
+  }
+
+  .content {
+    max-width: 640px;
+  }
 }
 
 .content {
-    margin: 6px;
-    padding-top: 20px;
-    width: 100%;
-    margin-left: auto;
-    margin-right: auto;
+  margin: 6px;
+  padding-top: 20px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .title {
-    margin-bottom: 1em;
-    font-weight: 900;
+  margin-bottom: 1em;
+  font-weight: 900;
 }
 
 .center {
-    display: block;
-    text-align: center;
-    margin-left: auto;
-    margin-right: auto;
+  display: block;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .plot {
-    width: 95%;
-    height: 0px;
-    margin-bottom: 1em;
+  width: 95%;
+  height: 0px;
+  margin-bottom: 1em;
 }
 
 label {
-    display: inline-block;
-    margin-top: 1em;
-    margin-left: 0.4em;
-    text-align: left;
-    font-size: 0.8rem;
+  display: inline-block;
+  margin-top: 1em;
+  margin-left: 0.2em;
+  text-align: left;
+  font-size: 0.8rem;
 }
 
 select {
-    margin-left: 0em;
-    margin-top: 0.4em;
-    font-size: 0.6rem;
-    text-overflow: ellipsis;
-    background-color: transparent;
-    border: 1px gray solid;
-    border-radius: 4px;
-    padding: 4px;
+  margin-left: 0em;
+  margin-top: 0.4em;
+  text-overflow: ellipsis;
+  background-color: transparent;
+  border: 1px gray solid;
+  border-radius: 4px;
+  padding: 4px;
+  font-size: 0.8rem;
+  width: 100%;
+}
+
+.drop-down {
+  max-width: 30rem;
 }
 
 .numbers {
-    font-size: 0.6rem;
-    margin-left: 0.1em;
-    margin-right: 0.1em;
-    display: table;
-    width: 100%;
+  font-size: 0.6rem;
+  margin-left: 0.1em;
+  margin-right: 0.1em;
+  display: table;
+  width: 100%;
 }
 
 .numbers table {
-    border-spacing: 0.6em 0.6em;
-    height: 100%;
+  border-spacing: 0.6em 0.6em;
+  height: 100%;
 }
 
 .numbers td {
-    vertical-align: baseline;
+  vertical-align: baseline;
 }
 
 .border {
-    margin-top: 5px;
-    margin-bottom: 5px;
-    border: 1px var(--favicon-blue) solid;
-    border-radius: 5px;
-    padding: 5px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  border: 1.5px var(--favicon-blue) solid;
+  border-radius: 5px;
+  padding: 5px;
 }
 
 @media (min-width: 400px) {
-    table#input {
-        float: left;
-        width: 48%;
-    }
-    .output {
-        float: right;
-        width: 48%;
-    }
+  table#input {
+    float: left;
+    width: 48%;
+  }
+
+  .output {
+    float: right;
+    width: 48%;
+  }
 }
 
 input[type="number"] {
-    font-size: 0.6rem;
-    margin-bottom: 0.3rem;
+  font-size: 0.8rem;
+  margin-bottom: 0.3rem;
+}
+
+td {
+  font-size: 0.8rem;
 }
 
 input {
-    width: 95%;
-    border: 1px gray solid;
-    border-radius: 4px;
-    padding: 3px 4px;
+  width: 95%;
+  border: 1px gray solid;
+  border-radius: 4px;
+  padding: 3px 4px;
 }
 
 .result {
-    font-weight: 800;
+  font-weight: 800;
 }
 
 button {
-    background-color: var(--favicon-green);
-    color: white;
-    border: 0px;
-    text-align: center;
-    padding: 4px 10px;
-    border-radius: 4px;
-    margin-top: 1rem;
+  background-color: var(--favicon-green);
+  color: white;
+  border: 0px;
+  text-align: center;
+  padding: 4px 10px;
+  border-radius: 4px;
+  margin-top: 1rem;
 }
 
 .resetBtn {
-    background-color: gray;
-    margin-right: 0.2rem;
+  background-color: gray;
+  margin-right: 0.2rem;
 }
 
 .error {
-    color: var(--favicon-red);
-    font-size: 0.8rem;
-    margin: 0.6rem 0;
+  color: var(--favicon-red);
+  font-size: 0.8rem;
+  margin: 0.6rem 0;
 }
 
 .footer {
-    display: block;
-    margin-top: auto;
-    font-style: italic;
-    font-size: 0.8rem;
+  display: block;
+  margin-top: auto;
+  font-style: italic;
+  font-size: 0.8rem;
 }
 
 .changed {
-    border: 1px var(--favicon-red) solid;
+  border: 1px var(--favicon-red) solid;
 }


### PR DESCRIPTION
Changes:

- Makes the text larger and easy to read
- Menu positions are consistent with G*Power
- HTML language server (the default from nvim/helix/vscode) autoformatted the HTML and CSS
- GitHub URL updated to new repo/org name

---

G*Power:
<img width="680" alt="image" src="https://github.com/poweranalyses-org/poweranalyses/assets/43353831/4adf79d5-9a0c-488d-a8d3-2bfd95763649">

---

Before (desktop):
<img width="739" alt="image" src="https://github.com/poweranalyses-org/poweranalyses/assets/43353831/ea6a0191-603a-45f8-be2a-d06b96454e3c">

After (desktop):
<img width="756" alt="image" src="https://github.com/poweranalyses-org/poweranalyses/assets/43353831/b309ab2f-1494-478d-a9e2-8f8fd6e3f36c">

---

Before (mobile):
<img width="386" alt="image" src="https://github.com/poweranalyses-org/poweranalyses/assets/43353831/facf63da-c4e2-41f0-8bc8-a2429a324ab2">

After (mobile):
<img width="390" alt="image" src="https://github.com/poweranalyses-org/poweranalyses/assets/43353831/3c4b33b0-9c0b-4bed-84af-03bac08e65b2">
