### PR TITLE
Implement `pnt` in Rust

### DIFF
--- a/dist/src/dpq.rs
+++ b/dist/src/dpq.rs
@@ -1,0 +1,49 @@
+#![allow(non_snake_case)]
+
+fn r_d__0(log_p: bool) -> f64 {
+    if log_p {
+        f64::NEG_INFINITY
+    } else {
+        0.0
+    }
+}
+
+fn r_d__1(log_p: bool) -> f64 {
+    if log_p {
+        0.0
+    } else {
+        1.0
+    }
+}
+
+pub fn r_dt_0(lower_tail: bool, log_p: bool) -> f64 {
+    if lower_tail {
+        r_d__0(log_p)
+    } else {
+        r_d__1(log_p)
+    }
+}
+
+pub fn r_dt_1(lower_tail: bool, log_p: bool) -> f64 {
+    if lower_tail {
+        r_d__1(log_p)
+    } else {
+        r_d__0(log_p)
+    }
+}
+
+fn r_d_val(x: f64, log_p: bool) -> f64 {
+    if log_p { x.ln() } else { x }
+}
+
+extern "C" {
+    fn log1p(x: f64) -> f64;
+}
+
+fn r_d_clog(p: f64, log_p: bool) -> f64 {
+    if log_p { unsafe { log1p(-p) } } else { 0.5 - p + 0.5 }
+}
+
+pub fn r_dt_val(x: f64, lower_tail: bool, log_p: bool) -> f64 {
+    if lower_tail { r_d_val(x, log_p) } else { r_d_clog(x, log_p) }
+}

--- a/dist/src/lib.rs
+++ b/dist/src/lib.rs
@@ -1,3 +1,8 @@
+mod dpq;
+mod nmath;
+mod pnt;
+mod rmath;
+
 extern "C" {
     fn pnt(t: f64, df: f64, ncp: f64, lower_tail: i32, log_p: i32) -> f64;
     fn qnt(p: f64, df: f64, ncp: f64, lower_tail: i32, log_p: i32) -> f64;

--- a/dist/src/lib.rs
+++ b/dist/src/lib.rs
@@ -4,7 +4,6 @@ mod pnt;
 mod rmath;
 
 extern "C" {
-    fn pnt(t: f64, df: f64, ncp: f64, lower_tail: i32, log_p: i32) -> f64;
     fn qnt(p: f64, df: f64, ncp: f64, lower_tail: i32, log_p: i32) -> f64;
 
     fn pnf(x: f64, df1: f64, df2: f64, ncp: f64, lower_tail: i32, log_p: i32) -> f64;

--- a/dist/src/lib.rs
+++ b/dist/src/lib.rs
@@ -39,7 +39,7 @@ impl NoncentralT {
 
 impl Distribution for NoncentralT {
     fn cdf(&self, x: f64, lower_tail: bool) -> f64 {
-        unsafe { pnt(x, self.v, self.lambda, lower_tail as i32, 0) }
+        pnt::pnt(x, self.v, self.lambda, lower_tail, false)
     }
     fn quantile(&self, x: f64, lower_tail: bool) -> f64 {
         unsafe { qnt(x, self.v, self.lambda, lower_tail as i32, 0) }

--- a/dist/src/nmath.rs
+++ b/dist/src/nmath.rs
@@ -1,0 +1,8 @@
+pub fn ml_warn_return_nan() -> f64 {
+    println!("argument out of domain");
+    return f64::NAN
+}
+
+pub fn r_finite(x: f64) -> bool {
+    x.is_finite()
+}

--- a/dist/src/pnt.rs
+++ b/dist/src/pnt.rs
@@ -36,7 +36,7 @@ extern "C" {
 }
 
 fn finis(mut tnc: f64, del: f64, negdel: bool, mut lower_tail: bool) -> f64 {
-    tnc = rmath::pnorm(-del, 0.0, 1.0, /*lower*/true, /*log_p*/false);
+    tnc += rmath::pnorm(-del, 0.0, 1.0, /*lower*/true, /*log_p*/false);
     lower_tail = lower_tail != negdel;
     if tnc > 1.0 - 1e-10 && lower_tail {
         println!("precision problem in pnt");
@@ -68,7 +68,7 @@ pub fn pnt(t: f64, df: f64, ncp: f64, lower_tail: bool, log_p: bool) -> f64 {
     let mut negdel: bool;
 
     let itrmax: i32 = 1000;
-    let errmax: f32 = 1e-12;
+    let errmax: f64 = 1e-12;
 
     if df <= 0.0 {
         nmath::ml_warn_return_nan();
@@ -98,13 +98,10 @@ pub fn pnt(t: f64, df: f64, ncp: f64, lower_tail: bool, log_p: bool) -> f64 {
         del = -ncp;
     }
 
-    if df > 4e5 || del*del > 2.0*rmath::M_LN2*(-(f64::MIN_EXP)) as f64 {
-        /*-- 2nd part: if del > 37.62, then p=0 below
-         FIXME: test should depend on `df', `tt' AND `del' ! */
-        /* Approx. from	 Abramowitz & Stegun 26.7.10 (p.949) */
-        s = 1./(4.*df);
-        return rmath::pnorm(tt*(1.0 - s), del,
-                            (1.0 + tt*tt*2.0*s).sqrt(),
+    if df > 4e5 || del*del > 2.0*rmath::M_LN2*(-(f64::MIN_EXP as f64)) {
+        s = 1.0/(4.0*df);
+        return rmath::pnorm(tt*(1.0 - s) as f64, del,
+                            (1.0 + tt*tt*2.0*s as f64).sqrt(),
                             lower_tail != negdel, log_p);
     }
 
@@ -139,7 +136,7 @@ pub fn pnt(t: f64, df: f64, ncp: f64, lower_tail: bool, log_p: bool) -> f64 {
         tnc = p * xodd + q * xeven;
 
         for it in 1..=itrmax {
-            a += 1.;
+            a += 1.0;
             xodd  -= godd;
             xeven -= geven;
             godd  *= x * (a + b - 1.0) / a;

--- a/dist/src/pnt.rs
+++ b/dist/src/pnt.rs
@@ -45,14 +45,14 @@ fn finis(mut tnc: f64, del: f64, negdel: bool, mut lower_tail: bool) -> f64 {
 }
 
 pub fn pnt(t: f64, df: f64, ncp: f64, lower_tail: bool, log_p: bool) -> f64 {
-    let mut albeta: f64;
+    let albeta: f64;
     let mut a: f64;
-    let mut b: f64;
-    let mut del: f64;
+    let b: f64;
+    let del: f64;
     let mut errbd: f64;
-    let mut lambda: f64;
+    let lambda: f64;
     let mut rxb: f64;
-    let mut tt: f64;
+    let tt: f64;
     let mut x: f64;
     // Long doubles can most likely be represented by f64 without problems:
     // https://en.wikipedia.org/wiki/Long_double
@@ -65,7 +65,7 @@ pub fn pnt(t: f64, df: f64, ncp: f64, lower_tail: bool, log_p: bool) -> f64 {
     let mut xeven: f64;
     let mut xodd: f64;
 
-    let mut negdel: bool;
+    let negdel: bool;
 
     let itrmax: i32 = 1000;
     let errmax: f64 = 1e-12;

--- a/dist/src/pnt.rs
+++ b/dist/src/pnt.rs
@@ -1,0 +1,166 @@
+/*
+ *  Mathlib : A C Library of Special Functions
+ *  Copyright (C) 1998-2015 The R Core Team
+ *  based on AS243 (C) 1989 Royal Statistical Society
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, a copy is available at
+ *  https://www.R-project.org/Licenses/
+ */
+
+/*  Algorithm AS 243  Lenth,R.V. (1989). Appl. Statist., Vol.38, 185-189.
+ *  ----------------
+ *  Cumulative probability at t of the non-central t-distribution
+ *  with df degrees of freedom (may be fractional) and non-centrality
+ *  parameter delta.
+ */
+
+use crate::dpq;
+use crate::nmath;
+use crate::rmath;
+
+extern "C" {
+    fn pt(x: f64, n: f64, lower_tail: i32, log_p: i32) -> f64;
+    fn lgammafn(x: f64) -> f64;
+    fn pbeta(x: f64, a: f64, b: f64, lower_tail: i32, log_p: i32) -> f64;
+}
+
+fn finis(mut tnc: f64, del: f64, negdel: bool, mut lower_tail: bool) -> f64 {
+    tnc = rmath::pnorm(-del, 0.0, 1.0, /*lower*/true, /*log_p*/false);
+    lower_tail = lower_tail != negdel;
+    if tnc > 1.0 - 1e-10 && lower_tail {
+        println!("precision problem in pnt");
+    }
+    dpq::r_dt_val(f64::min(tnc, 1.0), lower_tail, /*log_p*/false)
+}
+
+pub fn pnt(t: f64, df: f64, ncp: f64, lower_tail: bool, log_p: bool) -> f64 {
+    let mut albeta: f64;
+    let mut a: f64;
+    let mut b: f64;
+    let mut del: f64;
+    let mut errbd: f64;
+    let mut lambda: f64;
+    let mut rxb: f64;
+    let mut tt: f64;
+    let mut x: f64;
+    // Long doubles can most likely be represented by f64 without problems:
+    // https://en.wikipedia.org/wiki/Long_double
+    let mut geven: f64;
+    let mut godd: f64;
+    let mut p: f64;
+    let mut q: f64;
+    let mut s: f64;
+    let mut tnc: f64;
+    let mut xeven: f64;
+    let mut xodd: f64;
+
+    let mut negdel: bool;
+
+    let itrmax: i32 = 1000;
+    let errmax: f32 = 1e-12;
+
+    if df <= 0.0 {
+        nmath::ml_warn_return_nan();
+    }
+    if ncp == 0.0 {
+        return unsafe { pt(t, df, lower_tail as i32, log_p as i32) };
+    }
+
+    if !nmath::r_finite(t) {
+        return if t < 0.0 {
+            dpq::r_dt_0(lower_tail, log_p)
+        } else {
+            dpq::r_dt_1(lower_tail, log_p)
+        };
+    }
+
+    if t >= 0.0 {
+        negdel = false;
+        tt = t;
+        del = ncp;
+    } else {
+        if ncp > 40.0 && (!log_p || !lower_tail) {
+            return dpq::r_dt_0(lower_tail, log_p);
+        }
+        negdel = true;
+        tt = -t;
+        del = -ncp;
+    }
+
+    if df > 4e5 || del*del > 2.0*rmath::M_LN2*(-(f64::MIN_EXP)) as f64 {
+        /*-- 2nd part: if del > 37.62, then p=0 below
+         FIXME: test should depend on `df', `tt' AND `del' ! */
+        /* Approx. from	 Abramowitz & Stegun 26.7.10 (p.949) */
+        s = 1./(4.*df);
+        return rmath::pnorm(tt*(1.0 - s), del,
+                            (1.0 + tt*tt*2.0*s).sqrt(),
+                            lower_tail != negdel, log_p);
+    }
+
+    /* initialize twin series */
+    /* Guenther, J. (1978). Statist. Computn. Simuln. vol.6, 199. */
+
+    x = t * t;
+    rxb = df/(x + df);
+    x = x / (x + df);
+
+    if x > 0.0 {
+        lambda = del * del;
+        p = 0.5 * (-0.5 * lambda).exp();
+        if p == 0.0 {
+            println!("Underflow in pnt; |ncp| too large");
+            return dpq::r_dt_0(lower_tail, log_p);
+        }
+        q = rmath::M_SQRT_2dPI * p * del;
+        s = 0.5 - p;
+        if s < 1e-7 {
+            s = -0.5 * (-0.5 * lambda).exp_m1();
+        }
+        a = 0.5;
+        b = 0.5 * df;
+        rxb = rxb.powf(b);
+        albeta = rmath::M_LN_SQRT_PI + unsafe { lgammafn(b) - lgammafn(0.5 + b) };
+        xodd = unsafe { pbeta(x, a, b, /*lower*/true as i32, /*log_p*/false as i32) };
+        godd = 2. * rxb * (a * x.ln() - albeta).exp();
+        tnc = b * x;
+        xeven = if tnc < f64::EPSILON { tnc } else { 1. - rxb };
+        geven = tnc * rxb;
+        tnc = p * xodd + q * xeven;
+
+        for it in 1..=itrmax {
+            a += 1.;
+            xodd  -= godd;
+            xeven -= geven;
+            godd  *= x * (a + b - 1.0) / a;
+            geven *= x * (a + b - 0.5) / (a + 0.5);
+            p *= lambda / (2 * it) as f64;
+            q *= lambda / (2 * it + 1) as f64;
+            tnc += p * xodd + q * xeven;
+            s -= p;
+            if s < -1e-10 {
+                println!("precision problem in pnt");
+                return finis(tnc, del, negdel, lower_tail);
+            }
+            errbd = 2. * s * (xodd - godd);
+            if errbd.abs() < errmax as f64 {
+                return finis(tnc, del, negdel, lower_tail);
+            }
+            println!("pnt didn't converge");
+        }
+    } else {
+        tnc = 0.0;
+    }
+
+    return finis(tnc, del, negdel, lower_tail);
+}

--- a/dist/src/rmath.rs
+++ b/dist/src/rmath.rs
@@ -1,0 +1,13 @@
+#![allow(non_upper_case_globals)]
+
+pub const M_LN2: f64 = 0.693147180559945309417232121458; /* ln(2) */
+pub const M_SQRT_2dPI: f64 = 0.797884560802865355879892119869; /* sqrt(2/pi) */
+pub const M_LN_SQRT_PI: f64 = 0.572364942924700087071713675677; /* log(sqrt(pi)) */
+
+extern "C" {
+    fn pnorm5(x: f64, mu: f64, sigma: f64, lower_tail: i32, log_p: i32) -> f64;
+}
+
+pub fn pnorm(x: f64, mu: f64, sigma: f64, lower_tail: bool, log_p: bool) -> f64 {
+    unsafe { pnorm5(x, mu, sigma, lower_tail as i32, log_p as i32) }
+}


### PR DESCRIPTION
Works towards fixing #24.

This is a way in which we could get rid of C and, hence, emscripten. We just incrementally port the C code to Rust. It's a lot of work, but not super difficult. Once this is done, it should make other things such as plotting and handling the browser DOM easier, so then it's a net win?

@storopoli what do you think of this approach?

